### PR TITLE
Fix missing habit tracker components

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Footer: React.FC = () => (
+  <footer className="text-center text-sm text-gray-500 p-4 mt-8">
+    <p>&copy; {new Date().getFullYear()} Habit Optimizer</p>
+  </footer>
+);
+
+export default Footer;

--- a/components/HabitForm.tsx
+++ b/components/HabitForm.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+
+interface Props {
+  onAddHabit: (name: string, description?: string) => void;
+  onClose: () => void;
+}
+
+const HabitForm: React.FC<Props> = ({ onAddHabit, onClose }) => {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    onAddHabit(name.trim(), description.trim() || undefined);
+    setName('');
+    setDescription('');
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+      <form onSubmit={submit} className="bg-white p-6 rounded shadow w-80 space-y-4">
+        <h2 className="text-lg font-bold">新しい習慣</h2>
+        <input
+          value={name}
+          onChange={e => setName(e.target.value)}
+          placeholder="習慣名"
+          className="w-full border p-2 rounded"
+        />
+        <textarea
+          value={description}
+          onChange={e => setDescription(e.target.value)}
+          placeholder="説明 (任意)"
+          className="w-full border p-2 rounded"
+        />
+        <div className="flex justify-end gap-2">
+          <button type="button" onClick={onClose} className="px-3 py-1 rounded bg-gray-200">キャンセル</button>
+          <button type="submit" className="px-3 py-1 rounded bg-sky-600 text-white">追加</button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default HabitForm;

--- a/components/HabitList.tsx
+++ b/components/HabitList.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Habit } from '../types';
+
+interface Props {
+  habits: Habit[];
+  onToggleComplete: (id: string) => void;
+  onDelete: (id: string) => void;
+}
+
+const HabitList: React.FC<Props> = ({ habits, onToggleComplete, onDelete }) => (
+  <div className="space-y-4">
+    {habits.map(habit => (
+      <div key={habit.id} className="flex items-center justify-between bg-white p-4 rounded shadow">
+        <div>
+          <h3 className="font-semibold">{habit.name}</h3>
+          {habit.description && <p className="text-sm text-gray-500">{habit.description}</p>}
+          <p className="text-xs text-gray-400">連続: {habit.currentStreak}日 / 最長: {habit.longestStreak}日</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button onClick={() => onToggleComplete(habit.id)} className="bg-green-500 hover:bg-green-600 text-white px-3 py-1 rounded">
+            完了
+          </button>
+          <button onClick={() => onDelete(habit.id)} className="bg-red-500 hover:bg-red-600 text-white px-3 py-1 rounded">
+            削除
+          </button>
+        </div>
+      </div>
+    ))}
+    {habits.length === 0 && <p className="text-center text-gray-500">まだ習慣がありません</p>}
+  </div>
+);
+
+export default HabitList;

--- a/components/HabitSuggester.tsx
+++ b/components/HabitSuggester.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { SuggestedHabit } from '../types';
+
+interface Props {
+  onAddSuggestedHabit: (name: string, description?: string) => void;
+  onClose: () => void;
+  getHabitSuggestions: () => Promise<SuggestedHabit[]>;
+}
+
+const HabitSuggester: React.FC<Props> = ({ onAddSuggestedHabit, onClose, getHabitSuggestions }) => {
+  const [suggestions, setSuggestions] = useState<SuggestedHabit[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetch = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const s = await getHabitSuggestions();
+      setSuggestions(s);
+    } catch (e) {
+      console.error(e);
+      setError('取得に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+      <div className="bg-white p-6 rounded shadow w-96 space-y-4">
+        <h2 className="text-lg font-bold">習慣アイデア</h2>
+        <button onClick={fetch} className="px-3 py-1 rounded bg-sky-600 text-white">取得</button>
+        {loading && <p>読み込み中...</p>}
+        {error && <p className="text-red-500">{error}</p>}
+        <ul className="space-y-2">
+          {suggestions.map((s, idx) => (
+            <li key={idx} className="border p-2 rounded flex justify-between">
+              <div>
+                <p className="font-semibold">{s.name}</p>
+                {s.description && <p className="text-xs text-gray-500">{s.description}</p>}
+              </div>
+              <button onClick={() => onAddSuggestedHabit(s.name, s.description)} className="ml-2 text-sky-600">追加</button>
+            </li>
+          ))}
+        </ul>
+        <div className="text-right">
+          <button onClick={onClose} className="text-sm text-gray-600">閉じる</button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default HabitSuggester;

--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export const AddIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" {...props}>
+    <path d="M12 5v14m7-7H5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+  </svg>
+);
+
+export const LightBulbIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" {...props}>
+    <path d="M12 2a7 7 0 0 0-4 12.9V18a2 2 0 0 0 2 2h4a2 2 0 0 0 2-2v-3.1A7 7 0 0 0 12 2z" />
+  </svg>
+);
+
+export const SparklesIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" {...props}>
+    <path d="M5 3l2 4 4 2-4 2-2 4-2-4-4-2 4-2 2-4zM19 11l1 2 2 1-2 1-1 2-1-2-2-1 2-1 1-2z" />
+  </svg>
+);

--- a/components/MotivationalMessage.tsx
+++ b/components/MotivationalMessage.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+interface Props {
+  quote: string;
+  isLoading: boolean;
+  error: string | null;
+  onRefresh: () => void;
+}
+
+const MotivationalMessage: React.FC<Props> = ({ quote, isLoading, error, onRefresh }) => (
+  <div className="text-center my-4">
+    {isLoading ? (
+      <p>読み込み中...</p>
+    ) : error ? (
+      <p className="text-red-500">{error}</p>
+    ) : (
+      <blockquote className="italic">{quote}</blockquote>
+    )}
+    <button onClick={onRefresh} className="mt-2 text-sm text-sky-600">別の言葉を見る</button>
+  </div>
+);
+
+export default MotivationalMessage;

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const Navbar: React.FC = () => (
+  <header className="bg-sky-600 text-white p-4">
+    <h1 className="text-xl font-bold">Habit Optimizer</h1>
+  </header>
+);
+
+export default Navbar;

--- a/components/ReflectionModal.tsx
+++ b/components/ReflectionModal.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface Props {
+  prompt: string;
+  onClose: () => void;
+  isLoading: boolean;
+}
+
+const ReflectionModal: React.FC<Props> = ({ prompt, onClose, isLoading }) => (
+  <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
+    <div className="bg-white p-6 rounded shadow w-96 space-y-4">
+      <h2 className="text-lg font-bold">今日の振り返り</h2>
+      {isLoading ? <p>読み込み中...</p> : <p>{prompt}</p>}
+      <div className="text-right">
+        <button onClick={onClose} className="text-sm text-gray-600">閉じる</button>
+      </div>
+    </div>
+  </div>
+);
+
+export default ReflectionModal;

--- a/react-shim.d.ts
+++ b/react-shim.d.ts
@@ -1,0 +1,30 @@
+declare module 'react' {
+  export function useState(initial?: any): any;
+  export function useEffect(effect: any, deps?: any): void;
+  export function useCallback(callback: any, deps?: any): any;
+  export namespace React {
+    export type FC<P = any> = (props: P) => any;
+  }
+  const React: any;
+  export default React;
+}
+
+declare module 'react-dom/client' {
+  export function createRoot(container: any): { render: (c: any) => void };
+}
+
+declare namespace JSX {
+  interface IntrinsicElements {
+    [elemName: string]: any;
+  }
+}
+
+declare module 'react/jsx-runtime' {
+  export const jsx: any;
+  export const jsxs: any;
+  export const Fragment: any;
+}
+
+declare var process: {
+  env: Record<string, string | undefined>;
+};

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -1,0 +1,32 @@
+import { SuggestedHabit } from '../types';
+
+const API_KEY = process.env.GEMINI_API_KEY || process.env.API_KEY;
+const BASE_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=';
+
+const request = async (prompt: string): Promise<string> => {
+  const res = await fetch(BASE_URL + API_KEY, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })
+  });
+  if (!res.ok) {
+    throw new Error('API request failed');
+  }
+  const data = await res.json();
+  return data.candidates?.[0]?.content?.parts?.[0]?.text || '';
+};
+
+export const getMotivationalQuote = () =>
+  request('日本語で短いモチベーションの上がる格言を1つ教えて');
+
+export const getHabitSuggestions = async (): Promise<SuggestedHabit[]> => {
+  const text = await request('日本語で習慣のアイデアを3つ箇条書きで教えて');
+  return text
+    .split('\n')
+    .map(t => t.replace(/^[-*\s]+/, '').trim())
+    .filter(Boolean)
+    .map(line => ({ name: line }));
+};
+
+export const getReflectionPrompt = () =>
+  request('日本語で1日の振り返りの質問を1つ出してください');

--- a/services/localStorageService.ts
+++ b/services/localStorageService.ts
@@ -1,0 +1,23 @@
+import { Habit } from '../types';
+
+const HABITS_KEY = 'habits';
+
+export const getHabits = (): Habit[] => {
+  if (typeof localStorage === 'undefined') return [];
+  try {
+    const item = localStorage.getItem(HABITS_KEY);
+    return item ? JSON.parse(item) as Habit[] : [];
+  } catch (e) {
+    console.error('Failed to load habits from localStorage', e);
+    return [];
+  }
+};
+
+export const saveHabits = (habits: Habit[]): void => {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(HABITS_KEY, JSON.stringify(habits));
+  } catch (e) {
+    console.error('Failed to save habits to localStorage', e);
+  }
+};


### PR DESCRIPTION
## Summary
- add habit tracker components: navbar, list, form, etc.
- implement local storage and Gemini service helpers
- include stub React type declarations so TS can parse in this environment

## Testing
- `npx tsc --noEmit` *(fails: Cannot find namespace 'React' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6843d8fb6f44832ca9e262a77915ed41